### PR TITLE
ADD issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,29 @@
+name: "\U0001F41E Bug Report"
+description: Report an issue
+title: '[Bug]: '
+labels:
+  - 'bug'
+body:
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Describe the issue
+      description: A clear description of what the issue is. If you intend to submit a PR for this issue, please indicate. Thanks!
+      placeholder: Issue desription
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: What did you expect to happen?
+      description: A brief description what you thought should happen instead.
+      placeholder: Expected behaviour
+    validations:
+      required: true
+  - type: checkboxes
+    id: checked-existing-issues
+    attributes:
+      label: Have you checked that the issue has not already been raised?
+      options:
+        - label: I did not find any similar issues
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,26 @@
+name: "\U0001F4A1 Feature Request"
+description: Request a new feature or enhancement
+title: '[Feature]: '
+labels:
+  - 'feature'
+  - 'enhancement'
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: A concise and clear description of what problem this feature would solve.
+      placeholder: The problem is...
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: A concise description of the feature you would like to be implemented. You could also inlude suggestions on how it might be implemented!
+      placeholder: It would be great if...
+  - type: checkboxes
+    id: checked-existing-issues
+    attributes:
+      label: Have you checked that the issue has not already been raised?
+      options:
+        - label: I did not find any similar issues or feature requests
+          required: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 dll_config/**
 properHTMLdev/**
 .vscode/**
+node_modules
+package.json
+pnpm-lock.yaml


### PR DESCRIPTION
This PR adds two templates that can be used when creating a new issue.  The first is for bug reports, and the second is for feature requests and enhancement. The templates include required fields that the author must populate i.e. `problem` and `expected behaviour`. 

We could of course add more fields later or amend current ones, but this only serves to show what difference would adding this make. 

Note: the `.github` folder must be added to the main branch.